### PR TITLE
Improve build and test

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,6 +1,14 @@
 name: p4p_ext
 
-on: [push, pull_request, workflow_dispatch]
+on: 
+  push:
+    branches-ignore:
+      - "documentation"
+  pull_request:
+    branches-ignore:
+      - "documentation"
+  workflow_dispatch:
+    # Allow manual triggering of workflow
 
 jobs:
   lint:
@@ -23,7 +31,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest] #, mac-latest]
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
     runs-on: ${{ matrix.os }}
     continue-on-error: true
     steps:
@@ -60,6 +68,7 @@ jobs:
     name: Build distribution 📦
     needs: 
     - test
+    if: github.ref == 'refs/heads/main' # Only build dist on main
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Add Python 3.13 to test matrix. Tests but does not build distribution on branches other than main.

Changes on documentation branch do not trigger test and build, only GitHub Pages deployment.