### PR TITLE
40 add a cpswrite rule

### DIFF
--- a/examples/basic_server_recipe.yaml
+++ b/examples/basic_server_recipe.yaml
@@ -31,21 +31,21 @@
 #   initial: 17.5
 #   read_only: True
 
-# # DEV:RW:DOUBLE5:
-# #   description: "A double array"
-# #   type: "DOUBLE"
-# #   initial: [3,4,5,17.5,7,8]
-# #   control:
-# #     low: 1
-# #     high: 20
+DEV:RW:DOUBLE5:
+  description: "A double array"
+  type: "DOUBLE"
+  initial: [3,4,5,17.5,7,8]
+  control:
+    low: 1
+    high: 20
 
-# # DEV:RW:DOUBLEARR2:
-# #   description: "A double array using the default value 0 which is outside the control range"
-# #   type: "DOUBLE"
-# #   array_size: 6
-# #   control:
-# #     low: 1
-# #     high: 20
+DEV:RW:DOUBLEARR2:
+  description: "A double array using the default value 0 which is outside the control range"
+  type: "DOUBLE"
+  array_size: 6
+  control:
+    low: 1
+    high: 20
 
 # DEV:RW:DOUBLE6:
 #   description: "A PV with display limits configured but no precision etc"
@@ -94,9 +94,13 @@ DEV:RW:INT:
   initial: 3
 
 DEV:RW:INT1:
-  description: "An example integer PV"
+  description: "An example integer PV from a CPS crate"
   type: "INTEGER"
   initial: 2
+  hw_write:
+    hw: CPS
+    ip_addr: 123.456.78.90
+    channel_name: "a:crate:channel"
 
 # DEV:RO:INT:
 #   description: "An example int PV with limits"

--- a/p4pillon/config_reader.py
+++ b/p4pillon/config_reader.py
@@ -10,7 +10,11 @@ import yaml
 from p4pillon.definitions import PVTypes
 from p4pillon.pvrecipe import BasePVRecipe
 from p4pillon.server.server import Server
-from p4pillon.thread.pvrecipe import PVEnumRecipe, PVScalarArrayRecipe, PVScalarRecipe
+from p4pillon.thread.pvrecipe import (
+    PVEnumRecipe,
+    PVScalarArrayRecipe,
+    PVScalarRecipe,
+)
 
 logger = logging.getLogger(__name__)
 

--- a/p4pillon/config_reader.py
+++ b/p4pillon/config_reader.py
@@ -116,7 +116,7 @@ def process_config(pvname: str, pvdetails: dict[str, Any]) -> BasePVRecipe:
     else:
         pvrecipe = PVScalarRecipe(PVTypes[pvdetails["type"]], pvdetails["description"], initial)
 
-    supported_configs = [("read_only", bool), ("calc", dict)]
+    supported_configs = [("read_only", bool), ("calc", dict), ("hw_write", dict)]
     for config, config_type in supported_configs:
         # Process variables in the configuration that are attributes of the pvrecipe class
         temp_config = pvdetails.get(config)

--- a/p4pillon/pvrecipe.py
+++ b/p4pillon/pvrecipe.py
@@ -134,6 +134,8 @@ class BasePVRecipe(Generic[SharedPvT], ABC):
         kwargs = {}
         if hasattr(self, "calc"):
             kwargs["calc"] = self.calc
+        if hasattr(self, "hw_write"):
+            kwargs["hw_write"] = self.hw_write
 
         logger.debug(debug_str)
 

--- a/p4pillon/rules/__init__.py
+++ b/p4pillon/rules/__init__.py
@@ -6,6 +6,7 @@ from .alarm_ntenum_rule import AlarmNTEnumRule
 from .alarm_rule import AlarmRule
 from .calc_rule import CalcRule
 from .control_rule import ControlRule
+from .cps_write_rule import CPSWriteRule
 from .read_only_rule import ReadOnlyRule
 from .rules import BaseRule, RulesFlow, ScalarToArrayWrapperRule
 from .timestamp_rule import TimestampRule
@@ -17,6 +18,7 @@ __all__ = [
     "AlarmNTEnumRule",
     "CalcRule",
     "ControlRule",
+    "CPSWriteRule",
     "ReadOnlyRule",
     "RulesFlow",
     "ScalarToArrayWrapperRule",

--- a/p4pillon/rules/calc_rule.py
+++ b/p4pillon/rules/calc_rule.py
@@ -107,6 +107,8 @@ class CalcRule(BaseScalarRule):
             temp_monitor = self.MonitorCB(self._server, self._pv_name)
             self._subs.append(self._server._ctxt.monitor(pv, temp_monitor.cb))
 
+        return RulesFlow.CONTINUE
+
     def get_variables(self):
         """
         Return a list of the current values of the pvs in self._variables

--- a/p4pillon/rules/cps_write_rule.py
+++ b/p4pillon/rules/cps_write_rule.py
@@ -18,6 +18,13 @@ class CPSWriteRule(BaseScalarRule):
     """
 
     def __init__(self, **kwargs):
+        """
+        initialisation parameters can be passed in kwargs:
+            kwargs["hw_write"] = {"hw": "CPS"  # this is required to identify these as parameters for CPS
+                "ip_addr": "123.456.78.90"  # the ip address of the CPS crate
+                "channel_name": "crate:channel:name"  # the name of the channel on the crate this PV represents
+            }
+        """
         super().__init__()
         self._hw_write = {}
 
@@ -36,7 +43,7 @@ class CPSWriteRule(BaseScalarRule):
         """
         return None
 
-    def set_cps_write(self, hw_write) -> None:
+    def set_cps_write(self, hw_write: dict) -> None:
         """
         Set the parameters needed to write the value back to the channel on the crate.
         hw_write is a dictionary of the parameters:

--- a/p4pillon/rules/cps_write_rule.py
+++ b/p4pillon/rules/cps_write_rule.py
@@ -1,0 +1,126 @@
+"""
+Rule to write to a channel on a CPS crate.
+"""
+
+import logging
+
+import requests
+from p4p import Value
+
+from p4pillon.rules import BaseScalarRule, RulesFlow
+
+logger = logging.getLogger(__name__)
+
+
+class CPSWriteRule(BaseScalarRule):
+    """
+    This class implements a rule to write 
+    """
+
+    def __init__(self, **kwargs):
+        super().__init__()
+        self._hw_write = {}
+
+        if ("hw_write" in kwargs 
+            and "hw" in kwargs["hw_write"]
+            and kwargs["hw_write"]["hw"] == "CPS"
+        ):
+            self.set_cps_write(kwargs["hw_write"])
+
+    @property
+    def _name(self) -> str:
+        return "cps_write"
+
+    @property
+    def _fields(self) -> None:
+        """
+        A return value of None means this rule is not dependent on any fields in the PV and
+        will thus always be applicable.
+        """
+        return None
+
+    def set_cps_write(self, hw_write) -> None:
+        """
+        Set the parameters needed to write the value back to the channel on the crate.
+        hw_write is a dictionary of the parameters:
+            "ip_addr": the ip address of the crate
+            "channel_name": the channel name on the crate to write to
+
+        """
+
+        if "ip_addr" in hw_write and isinstance(hw_write["ip_addr"], str):
+            self._hw_write["ip_addr"] = hw_write["ip_addr"]
+
+        if ("channel_name" in hw_write 
+            and isinstance(hw_write["channel_name"], str)
+        ):
+            self._hw_write["channel_name"] = hw_write["channel_name"]
+
+    def init_rule(self, value: Value, **kwargs):
+        """
+        Method to initialise writing to the CPS crate.
+        """
+        logger.debug("Evaluating %s.init_rule", self._name)
+
+        # test writing the channel to the crate.
+        ret_val = self.cps_write(value["value"])
+
+        return ret_val
+
+    def post_rule(self, oldpvstate: Value, newpvstate: Value) -> RulesFlow:
+        """
+        Evaluate the calculation.
+          The syntax for using pvs in the calc string is to use the pv array, e.g. 'pv[0]' to use the first variable
+          in self._variables. This requires the variable below (i.e. pv = self.getVariables()) to have the same name.
+        """
+        logger.debug("Evaluating %s.post_rule", self._name)
+
+        ret_val = self.cps_write(newpvstate["value"])
+
+        return ret_val
+
+    def cps_write(self, value) -> RulesFlow:
+        """
+        Compose the XML to update the channel and send it to the crate
+        """
+        if not self.validate_hw_write():
+            raise ValueError("hw_write dictionary not set correctly")
+
+        ret_val = RulesFlow.CONTINUE
+
+        xml_header = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+        xml_db = f"<database><channel name=\"{self._hw_write['channel_name']}\"><value>{value}</value></cahnnel></database>"
+        xml_string = xml_header + xml_db
+
+        url = f"http://{self._hw_write['ip_addr']}/scripts/database.vi?function=10"
+
+        logger.debug(f"Sending {xml_string} to {url}")
+
+        logger.debug("\n\n\ debugging \n\n")
+        r = requests.post(
+            url,
+            data=xml_string,
+            headers={"Content-Type": "text/xml", "Connection": "Keep-Alive"},
+        )
+
+        if r.status_code != 200 or r.status_code != 204:
+            # request failed
+            logging.error(
+                f"Sending XML to CPS crate {self._hw_write['ip_addr']} failed with status code {r.status_code}"
+            )
+            ret_val = RulesFlow.TERMINATE
+
+        return ret_val
+    
+    def validate_hw_write(self) -> bool:
+        """
+        Check that the required parameters have been set in the self._hw_write dictinoary
+        """
+
+        if ("ip_addr" not in self._hw_write
+            or "channel_name" not in self._hw_write
+        ):
+            logger.error(f"self._hw_write not set correctly self._hw_write={self._hw_write}")
+            return False
+
+        return True

--- a/p4pillon/rules/cps_write_rule.py
+++ b/p4pillon/rules/cps_write_rule.py
@@ -7,24 +7,21 @@ import logging
 import requests
 from p4p import Value
 
-from p4pillon.rules import BaseScalarRule, RulesFlow
+from .rules import BaseScalarRule, RulesFlow
 
 logger = logging.getLogger(__name__)
 
 
 class CPSWriteRule(BaseScalarRule):
     """
-    This class implements a rule to write 
+    This class implements a rule to write
     """
 
     def __init__(self, **kwargs):
         super().__init__()
         self._hw_write = {}
 
-        if ("hw_write" in kwargs 
-            and "hw" in kwargs["hw_write"]
-            and kwargs["hw_write"]["hw"] == "CPS"
-        ):
+        if "hw_write" in kwargs and "hw" in kwargs["hw_write"] and kwargs["hw_write"]["hw"] == "CPS":
             self.set_cps_write(kwargs["hw_write"])
 
     @property
@@ -51,9 +48,7 @@ class CPSWriteRule(BaseScalarRule):
         if "ip_addr" in hw_write and isinstance(hw_write["ip_addr"], str):
             self._hw_write["ip_addr"] = hw_write["ip_addr"]
 
-        if ("channel_name" in hw_write 
-            and isinstance(hw_write["channel_name"], str)
-        ):
+        if "channel_name" in hw_write and isinstance(hw_write["channel_name"], str):
             self._hw_write["channel_name"] = hw_write["channel_name"]
 
     def init_rule(self, value: Value, **kwargs):
@@ -88,8 +83,10 @@ class CPSWriteRule(BaseScalarRule):
 
         ret_val = RulesFlow.CONTINUE
 
-        xml_header = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
-        xml_db = f"<database><channel name=\"{self._hw_write['channel_name']}\"><value>{value}</value></cahnnel></database>"
+        xml_header = '<?xml version="1.0" encoding="UTF-8"?>'
+        xml_db = (
+            f'<database><channel name="{self._hw_write["channel_name"]}"><value>{value}</value></cahnnel></database>'
+        )
         xml_string = xml_header + xml_db
 
         url = f"http://{self._hw_write['ip_addr']}/scripts/database.vi?function=10"
@@ -111,15 +108,13 @@ class CPSWriteRule(BaseScalarRule):
             ret_val = RulesFlow.TERMINATE
 
         return ret_val
-    
+
     def validate_hw_write(self) -> bool:
         """
         Check that the required parameters have been set in the self._hw_write dictinoary
         """
 
-        if ("ip_addr" not in self._hw_write
-            or "channel_name" not in self._hw_write
-        ):
+        if "ip_addr" not in self._hw_write or "channel_name" not in self._hw_write:
             logger.error(f"self._hw_write not set correctly self._hw_write={self._hw_write}")
             return False
 

--- a/p4pillon/sharednt.py
+++ b/p4pillon/sharednt.py
@@ -18,6 +18,7 @@ from p4pillon.rules import (
     AlarmRule,
     CalcRule,
     ControlRule,
+    CPSWriteRule,
     ScalarToArrayWrapperRule,
     TimestampRule,
     ValueAlarmRule,
@@ -75,6 +76,12 @@ class SharedNT(SharedPV, ABC):
                             AlarmRule()
                         )  # ScalarToArrayWrapperRule unnecessary - no access to values
                         handler["alarm_limit"] = ComposeableRulesHandler(ScalarToArrayWrapperRule(ValueAlarmRule()))
+                        if "hw_write" in kwargs:
+                            if kwargs["hw_write"]["hw"] == "CPS":
+                                handler["hw_write"] = ComposeableRulesHandler(CPSWriteRule(**kwargs))
+                            kwargs.pop(
+                                "hw_write"
+                            )  # Removing this from kwargs as it shouldn't be passed to super().__init__(**kwargs)
                         handler["timestamp"] = ComposeableRulesHandler(TimestampRule())
                     elif nttype_str.startswith("epics:nt/NTScalar"):
                         if "calc" in kwargs:
@@ -85,6 +92,12 @@ class SharedNT(SharedPV, ABC):
                         handler["control"] = ComposeableRulesHandler(ControlRule())
                         handler["alarm"] = ComposeableRulesHandler(AlarmRule())
                         handler["alarm_limit"] = ComposeableRulesHandler(ValueAlarmRule())
+                        if "hw_write" in kwargs:
+                            if kwargs["hw_write"]["hw"] == "CPS":
+                                handler["hw_write"] = ComposeableRulesHandler(CPSWriteRule(**kwargs))
+                            kwargs.pop(
+                                "hw_write"
+                            )  # Removing this from kwargs as it shouldn't be passed to super().__init__(**kwargs)
                         handler["timestamp"] = ComposeableRulesHandler(TimestampRule())
                     else:
                         raise TypeError(f"Unrecognised NT type: {nttype_str}")
@@ -95,6 +108,12 @@ class SharedNT(SharedPV, ABC):
                     if handler_constructors:
                         alarm_ntenum_constructor = handler_constructors.get("alarmNTEnum", None)
                     handler["alarmNTEnum"] = ComposeableRulesHandler(AlarmNTEnumRule(alarm_ntenum_constructor))
+                    if "hw_write" in kwargs:
+                        if kwargs["hw_write"]["hw"] == "CPS":
+                            handler["hw_write"] = ComposeableRulesHandler(CPSWriteRule(**kwargs))
+                        kwargs.pop(
+                            "hw_write"
+                        )  # Removing this from kwargs as it shouldn't be passed to super().__init__(**kwargs)
                     handler["timestamp"] = ComposeableRulesHandler(TimestampRule())
                 case _:
                     if not nttype_str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ requires-python = ">=3.10"
 dependencies = [
     "p4p>=4.2.1",
     "pyyaml>=6.0.2",
+    "requests>=2.32.3",
 ]
 classifiers = [
   "Development Status :: 2 - Pre-Alpha",

--- a/tests/unit/test_rules.py
+++ b/tests/unit/test_rules.py
@@ -6,7 +6,15 @@ import pytest
 from p4p.nt import NTScalar
 
 from p4pillon.definitions import AlarmSeverity
-from p4pillon.rules import CalcRule, ControlRule, RulesFlow, ScalarToArrayWrapperRule, TimestampRule, ValueAlarmRule
+from p4pillon.rules import (
+    CalcRule,
+    ControlRule,
+    CPSWriteRule,
+    RulesFlow,
+    ScalarToArrayWrapperRule,
+    TimestampRule,
+    ValueAlarmRule,
+)
 from p4pillon.utils import overwrite_unmarked
 
 
@@ -521,3 +529,10 @@ class TestCalcRule:
         assert len(rule._variables) == 1 and rule._variables[0] == "a:pv:name"
         assert rule._server == "fakeServer"
         assert rule._pv_name == "this:pv:name"
+
+
+class TestCPSWriteRule:
+    def test_create_cps_write_rule(self):
+        rule = CPSWriteRule()
+
+        assert rule._name == "cps_write"

--- a/tests/unit/test_rules.py
+++ b/tests/unit/test_rules.py
@@ -534,5 +534,19 @@ class TestCalcRule:
 class TestCPSWriteRule:
     def test_create_cps_write_rule(self):
         rule = CPSWriteRule()
-
         assert rule._name == "cps_write"
+
+    def test_set_cps_write(self):
+        hw_write = {"hw": "CPS", "ip_addr": "192.168.55.55", "channel_name": "a:chan:name"}
+        rule = CPSWriteRule(hw_write=hw_write)
+
+        assert rule._hw_write != {} and len(rule._hw_write) == 2
+        assert "ip_addr" in rule._hw_write and rule._hw_write["ip_addr"] == "192.168.55.55"
+        assert "channel_name" in rule._hw_write and rule._hw_write["channel_name"] == "a:chan:name"
+
+        hw_write = {"ip_addr": "192.168.25.25", "channel_name": "another:chan:name"}
+        rule.set_cps_write(hw_write)
+
+        assert rule._hw_write != {} and len(rule._hw_write) == 2
+        assert "ip_addr" in rule._hw_write and rule._hw_write["ip_addr"] == "192.168.25.25"
+        assert "channel_name" in rule._hw_write and rule._hw_write["channel_name"] == "another:chan:name"

--- a/tests/unit/thread/test_config_reader.py
+++ b/tests/unit/thread/test_config_reader.py
@@ -5,7 +5,11 @@ import pytest
 
 from p4pillon.config_reader import parse_config
 from p4pillon.definitions import PVTypes
-from p4pillon.thread.pvrecipe import PVEnumRecipe, PVScalarArrayRecipe, PVScalarRecipe
+from p4pillon.thread.pvrecipe import (
+    PVEnumRecipe,
+    PVScalarArrayRecipe,
+    PVScalarRecipe,
+)
 
 
 @pytest.mark.parametrize(
@@ -76,3 +80,35 @@ def test_parse_config_with_server_enum(name, config, pvtype):
     assert server.add_pv.call_args_list[0][0][1].initial_value == config["initial"]
     assert isinstance(server.add_pv.call_args_list[0][0][1], PVEnumRecipe)
     assert server.add_pv.call_args_list[0][0][0] == name
+
+
+@pytest.mark.parametrize(
+    "name, config",
+    [
+        (
+            "TEST:PV:DOUBLE",
+            {
+                "initial": 0.0,
+                "type": "DOUBLE",
+                "hw_write": {"hw": "CPS", "ip_addr": "123.456.78.90", "channel_name": "a:double:channel"},
+            },
+        ),
+        (
+            "TEST:PV:INTEGER",
+            {
+                "initial": 0,
+                "type": "INTEGER",
+                "hw_write": {"hw": "CPS", "ip_addr": "123.456.78.90", "channel_name": "an:int:channel"},
+            },
+        ),
+    ],
+)
+def test_parse_config_with_cps(name, config):
+    server = MagicMock()
+
+    config["description"] = "test"
+
+    recipes = parse_config({name: config}, server)
+
+    assert len(recipes) == 1
+    assert hasattr(recipes[name], "hw_write")


### PR DESCRIPTION
The rule uses an http post request to send an xml database to the crate with the channel name and value to be updated. The rule is added to the CompositeHandler just before the timestamp rule. The following YAML syntax has been defined to initialise the rule:
``` 
hw_write:
  hw: "CPS"
  ip_addr: 123.456.78.90
  channel_name: "a:channel:name"
```
`hw_write["hw"]` must equal `"CPS"` in order for the CPSWriteRule to be applied. This allows different hardware to use the same tag `hw_write`. 
The same rule is used to write to arrays though this needs to be tested with a crate.
Currently the code is not able to tell if an update to the PV has been made after reading values from the crate. This means the crate will be written back to even if the PV has been updated due to a read from the crate. A way around this should be implemented in the future.