### PR TITLE
Fix double wrap by NTNDArray

### DIFF
--- a/p4pillon/server/raw.py
+++ b/p4pillon/server/raw.py
@@ -5,6 +5,7 @@ Patch in p4p PR #172 - support for open(), post(), and close() handler functions
 import logging
 from abc import ABC
 
+from p4p._p4p import SharedPV as _RawSharedPV
 from p4p.server.raw import SharedPV as _SharedPV
 
 _log = logging.getLogger(__name__)
@@ -159,7 +160,9 @@ class SharedPV(_SharedPV, ABC):
         else:
             open_fn(V)
 
-        _SharedPV.open(self, V)
+        # Call the C-extension base directly, bypassing p4p.server.raw.SharedPV.open(),
+        # which would wrap() V a second time (V is already wrapped above).
+        _RawSharedPV.open(self, V)
 
     def post(self, value, **kwargs):
         """Provide an update to the Value of this PV.
@@ -185,7 +188,9 @@ class SharedPV(_SharedPV, ABC):
         else:
             post_fn(self, V)
 
-        _SharedPV.post(self, V)
+        # Call the C-extension base directly, bypassing p4p.server.raw.SharedPV.post(),
+        # which would wrap() V a second time (V is already wrapped above).
+        _RawSharedPV.post(self, V)
 
     def close(self, destroy=False):
         """Close PV, disconnecting any clients.

--- a/tests/unit/server/test_sharedpv_asyncio.py
+++ b/tests/unit/server/test_sharedpv_asyncio.py
@@ -1,4 +1,5 @@
-from p4p.nt import NTScalar
+import numpy
+from p4p.nt import NTNDArray, NTScalar
 
 from p4pillon.server.asyncio import Handler, SharedPV
 
@@ -51,3 +52,22 @@ class TestAsyncioHandler:
         self.pv.close()
         del self.handler
         del self.pv
+
+
+class TestNoDoubleWrapOfInitialValue:
+    """Regression tests for `SharedPV.open()`/`.post()` each wrapping `value`
+    via `nt.wrap()` themselves before delegating to p4p's own (already
+    wrapping) `SharedPV.open()`/`.post()`, which wraps a second time. Harmless
+    for `NTScalar`, whose `wrap()` tolerates being fed an already-wrapped
+    `Value` -- but `NTNDArray.wrap()` assumes a raw `numpy.ndarray` and raises
+    when handed a `Value` on the second pass.
+    """
+
+    def test_open_with_ntndarray_does_not_double_wrap(self):
+        pv = SharedPV(nt=NTNDArray(), initial=numpy.zeros((4, 4)))
+        assert numpy.array_equal(numpy.asarray(pv.current()).flatten(), numpy.zeros(16))
+
+    def test_post_with_ntndarray_does_not_double_wrap(self):
+        pv = SharedPV(nt=NTNDArray(), initial=numpy.zeros((4, 4)))
+        pv.post(numpy.ones((4, 4)))
+        assert numpy.array_equal(numpy.asarray(pv.current()).flatten(), numpy.ones(16))

--- a/tests/unit/server/test_sharedpv_thread.py
+++ b/tests/unit/server/test_sharedpv_thread.py
@@ -1,4 +1,5 @@
-from p4p.nt import NTScalar
+import numpy
+from p4p.nt import NTNDArray, NTScalar
 
 from p4pillon.server.thread import Handler, SharedPV
 
@@ -51,3 +52,22 @@ class TestThreadHandler:
         self.pv.close()
         del self.handler
         del self.pv
+
+
+class TestNoDoubleWrapOfInitialValue:
+    """Regression tests for `SharedPV.open()`/`.post()` each wrapping `value`
+    via `nt.wrap()` themselves before delegating to p4p's own (already
+    wrapping) `SharedPV.open()`/`.post()`, which wraps a second time. Harmless
+    for `NTScalar`, whose `wrap()` tolerates being fed an already-wrapped
+    `Value` -- but `NTNDArray.wrap()` assumes a raw `numpy.ndarray` and raises
+    when handed a `Value` on the second pass.
+    """
+
+    def test_open_with_ntndarray_does_not_double_wrap(self):
+        pv = SharedPV(nt=NTNDArray(), initial=numpy.zeros((4, 4)))
+        assert numpy.array_equal(numpy.asarray(pv.current()).flatten(), numpy.zeros(16))
+
+    def test_post_with_ntndarray_does_not_double_wrap(self):
+        pv = SharedPV(nt=NTNDArray(), initial=numpy.zeros((4, 4)))
+        pv.post(numpy.ones((4, 4)))
+        assert numpy.array_equal(numpy.asarray(pv.current()).flatten(), numpy.ones(16))


### PR DESCRIPTION
This is a bug which exists in all the NT types but only blows up in NTNDArray. Because of the implementation it tries to wrap any values passed into open() twice. NTScalars, NTEnums, and NTTables just no-op the second wrap but NTNDArray has a different implementation involving numpy and instead crashes out.

This PR includes a pair of regression tests for `thread` and `asyncio` and the simple fix in `server/raw.py`.