### PR TITLE
Update calc_rule to use safer SimpleEval

### DIFF
--- a/p4pillon/rules/calc_rule.py
+++ b/p4pillon/rules/calc_rule.py
@@ -2,15 +2,24 @@
 Rule to implement calc record functionality.
 """
 
-import ast
+from __future__ import annotations
+
 import logging
-import math as m  # noqa: F401
+import math as m
+from typing import TYPE_CHECKING, Any
 
 from p4p import Value
+from simpleeval import ModuleWrapper, SimpleEval
 
 from .rules import BaseScalarRule, RulesFlow, SupportedNTTypes
 
+if TYPE_CHECKING:
+    from p4pillon.server.server import Server
+
 logger = logging.getLogger(__name__)
+
+# Attributes of the math module that calc expressions are permitted to call, e.g. "m.sin(pv[0])".
+_ALLOWED_MATH_ATTRS = frozenset(name for name in dir(m) if not name.startswith("_"))
 
 
 class CalcRule(BaseScalarRule):
@@ -29,36 +38,36 @@ class CalcRule(BaseScalarRule):
                     dependent PV is updated.
     """
 
-    def __init__(self, **kwargs):
+    def __init__(self, **kwargs) -> None:
         super().__init__()
-        self._variables = []
+        self._variables: list[str] = []
         self._calc_str: str = ""
         self.set_calc(calc=kwargs)
 
     name = "calc"
-    nttypes = [SupportedNTTypes.ALL]
-    fields = []
-    add_automatically = False
+    nttypes: list[SupportedNTTypes] | None = [SupportedNTTypes.ALL]
+    fields: list[str] | None = []
+    add_automatically: bool = False
 
     class MonitorCB:
         """
         The MonitorCB class is used to provide call back methods for subscribing to Context.monitor
         """
 
-        def __init__(self, server, pv_name):
+        def __init__(self, server: Server, pv_name: str) -> None:
             """
             This class is used within  rule to provide a call back method for Context.monitor
             The rule_method is the method that the call back will pass the value on to.
             """
-            self._server = server
-            self._pv_name = pv_name
+            self._server: Server = server
+            self._pv_name: str = pv_name
 
-        def cb(self, v: Value):
+        def cb(self, v: Value) -> None:
             """This callback "cb" is part of the context.monitor() functionality.
             See https://epics-base.github.io/p4p/client.html#monitor for further information."""
             self._server.put_pv_value(self._pv_name, {})
 
-    def set_calc(self, calc: dict) -> None:
+    def set_calc(self, calc: dict[str, Any]) -> None:
         """
         Define the calculation to be performed.
         The required argument calc is a dictionary with the following keys:
@@ -68,18 +77,19 @@ class CalcRule(BaseScalarRule):
             self._calc_str = calc["calc_str"]
 
         if "variables" in calc:
-            if type(calc["variables"]) is list:
-                self._variables = calc["variables"]
-            if type(calc["variables"]) is str:
-                self._variables = [calc["variables"]]
+            variables = calc["variables"]
+            if isinstance(variables, list):
+                self._variables = variables
+            elif isinstance(variables, str):
+                self._variables = [variables]
 
         if "server" in calc:
-            self._server = calc["server"]
+            self._server: Server = calc["server"]
 
         if "pv_name" in calc:
-            self._pv_name = calc["pv_name"]
+            self._pv_name: str = calc["pv_name"]
 
-    def init_rule(self, value: Value, **kwargs):
+    def init_rule(self, newpvstate: Value) -> RulesFlow:
         """
         Method to initialise monitor call backs for the variables to be monitored.
         This should be added as an on start method when creating the pv.
@@ -92,18 +102,20 @@ class CalcRule(BaseScalarRule):
         ):
             logger.error("calc rule not initialised correctly")
             raise ValueError
-        logger.debug(f"value is {value}, calc is {self._calc_str}, variables are {self._variables}")
+        logger.debug(f"value is {newpvstate}, calc is {self._calc_str}, variables are {self._variables}")
 
         self._subs = []
         for pv in self._variables:
             temp_monitor = self.MonitorCB(self._server, self._pv_name)
             self._subs.append(self._server._ctxt.monitor(pv, temp_monitor.cb))
 
-    def get_variables(self):
+        return RulesFlow.CONTINUE
+
+    def get_variables(self) -> list[Any] | None:
         """
         Return a list of the current values of the pvs in self._variables
         """
-        pvs = []
+        pvs: list[Any] = []
 
         for pv_name in self._variables:
             try:
@@ -114,7 +126,7 @@ class CalcRule(BaseScalarRule):
                 pvs.append(val)
             except Exception:
                 # If there's an error getting the value of a pv return None
-                logging.error("Failed to get pv %s", pv_name)
+                logging.exception("Failed to get pv %s", pv_name)
                 return None
 
         return pvs
@@ -135,8 +147,7 @@ class CalcRule(BaseScalarRule):
         if pv is None:
             return RulesFlow.ABORT
 
-        node = ast.parse(self._calc_str, mode="eval")
-
-        newpvstate["value"] = eval(compile(node, "<string>", "eval"))
+        evaluator = SimpleEval(names={"pv": pv, "m": ModuleWrapper(m, allowed_attrs=_ALLOWED_MATH_ATTRS)})
+        newpvstate["value"] = evaluator.eval(self._calc_str)
 
         return ret_val

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ requires-python = ">=3.10"
 dependencies = [
     "p4p>=4.2.1",
     "pyyaml>=6.0.2",
+    "simpleeval>=1.0.3",
 ]
 classifiers = [
   "Development Status :: 2 - Pre-Alpha",

--- a/tests/unit/rules/test_calc_rule.py
+++ b/tests/unit/rules/test_calc_rule.py
@@ -40,7 +40,9 @@ class TestCalcRuleConfiguration:
         """A single variable name string is wrapped into a one-element list."""
         rule = CalcRule()
 
-        rule.set_calc({"calc_str": "pv[0]+10", "variables": "a:pv:name", "server": "fakeServer", "pv_name": "this:pv:name"})
+        rule.set_calc(
+            {"calc_str": "pv[0]+10", "variables": "a:pv:name", "server": "fakeServer", "pv_name": "this:pv:name"}
+        )
 
         assert rule._calc_str == "pv[0]+10"
         assert rule._variables == ["a:pv:name"]

--- a/tests/unit/rules/test_calc_rule.py
+++ b/tests/unit/rules/test_calc_rule.py
@@ -1,0 +1,127 @@
+import math
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from p4p import Value
+from p4p.nt import NTScalar
+from simpleeval import InvalidExpression
+
+from p4pillon.rules import CalcRule
+from p4pillon.rules.rules import RulesFlow
+
+
+def make_calc_rule(calc_str: str, variables: str | list[str], pv_values: list[Any]) -> tuple[CalcRule, MagicMock]:
+    """Build a CalcRule with a mock server that returns pv_values in order for get_pv_value calls."""
+    server = MagicMock()
+    server.__class__.__name__ = "Server"
+    server.get_pv_value.side_effect = pv_values
+
+    rule = CalcRule()
+    rule.set_calc(
+        {
+            "calc_str": calc_str,
+            "variables": variables,
+            "server": server,
+            "pv_name": "TEST:PV:CALC",
+        }
+    )
+    return rule, server
+
+
+class TestCalcRuleConfiguration:
+    def test_create_calc_rule(self) -> None:
+        rule = CalcRule()
+
+        assert rule.name == "calc"
+
+    def test_set_calc_normalises_single_variable_to_list(self) -> None:
+        rule = CalcRule()
+
+        rule.set_calc({"calc_str": "pv[0]+10", "variables": "a:pv:name", "server": "fakeServer", "pv_name": "this:pv:name"})
+
+        assert rule._calc_str == "pv[0]+10"
+        assert rule._variables == ["a:pv:name"]
+        assert rule._server == "fakeServer"
+        assert rule._pv_name == "this:pv:name"
+
+    def test_set_calc_keeps_variable_list(self) -> None:
+        rule = CalcRule()
+
+        rule.set_calc({"variables": ["a:pv:name", "b:pv:name"]})
+
+        assert rule._variables == ["a:pv:name", "b:pv:name"]
+
+
+class TestCalcRuleGetVariables:
+    def test_get_variables_returns_values_in_order(self) -> None:
+        rule, _ = make_calc_rule("pv[0]", ["a:pv:name", "b:pv:name"], [1.0, 2.0])
+
+        assert rule.get_variables() == [1.0, 2.0]
+
+    def test_get_variables_returns_none_if_a_pv_is_missing(self) -> None:
+        rule, _ = make_calc_rule("pv[0]", ["a:pv:name", "b:pv:name"], [1.0, None])
+
+        assert rule.get_variables() is None
+
+    def test_get_variables_returns_none_on_exception(self) -> None:
+        rule, server = make_calc_rule("pv[0]", ["a:pv:name"], [1.0])
+        server.get_pv_value.side_effect = RuntimeError("boom")
+
+        assert rule.get_variables() is None
+
+
+class TestCalcRulePostRule:
+    def test_post_rule_evaluates_single_variable(self) -> None:
+        rule, _ = make_calc_rule("pv[0]+10", "a:pv:name", [1.0])
+
+        old_state: Value = NTScalar("d").wrap(0.0)
+        new_state: Value = NTScalar("d").wrap(0.0)
+
+        result = rule.post_rule(old_state, new_state)
+
+        assert result is RulesFlow.CONTINUE
+        assert new_state["value"] == 11.0
+
+    def test_post_rule_evaluates_multiple_variables_in_order(self) -> None:
+        rule, _ = make_calc_rule("pv[0]+2.12*pv[1]", ["a:pv:name", "b:pv:name"], [3.0, 4.0])
+
+        new_state: Value = NTScalar("d").wrap(0.0)
+
+        rule.post_rule(new_state, new_state)
+
+        assert new_state["value"] == pytest.approx(3.0 + 2.12 * 4.0)
+
+    def test_post_rule_supports_math_module_functions(self) -> None:
+        rule, _ = make_calc_rule("pv[0]*m.sin(pv[1])", ["a:pv:name", "b:pv:name"], [3.0, 4.0])
+
+        new_state: Value = NTScalar("d").wrap(0.0)
+
+        rule.post_rule(new_state, new_state)
+
+        assert new_state["value"] == pytest.approx(3.0 * math.sin(4.0))
+
+    def test_post_rule_aborts_if_a_variable_is_missing(self) -> None:
+        rule, _ = make_calc_rule("pv[0]", ["a:pv:name"], [None])
+
+        new_state: Value = NTScalar("d").wrap(0.0)
+
+        result = rule.post_rule(new_state, new_state)
+
+        assert result is RulesFlow.ABORT
+
+    @pytest.mark.parametrize(
+        "malicious_calc_str",
+        [
+            "__import__('os').system('echo pwned')",
+            "().__class__.__bases__[0].__subclasses__()",
+            "open('/etc/passwd').read()",
+        ],
+    )
+    def test_post_rule_rejects_unsafe_expressions(self, malicious_calc_str: str) -> None:
+        rule, _ = make_calc_rule(malicious_calc_str, ["a:pv:name"], [1.0])
+
+        new_state: Value = NTScalar("d").wrap(0.0)
+
+        with pytest.raises(InvalidExpression):
+            rule.post_rule(new_state, new_state)

--- a/tests/unit/rules/test_calc_rule.py
+++ b/tests/unit/rules/test_calc_rule.py
@@ -31,11 +31,13 @@ def make_calc_rule(calc_str: str, variables: str | list[str], pv_values: list[An
 
 class TestCalcRuleConfiguration:
     def test_create_calc_rule(self) -> None:
+        """A freshly constructed CalcRule is registered under the name "calc"."""
         rule = CalcRule()
 
         assert rule.name == "calc"
 
     def test_set_calc_normalises_single_variable_to_list(self) -> None:
+        """A single variable name string is wrapped into a one-element list."""
         rule = CalcRule()
 
         rule.set_calc({"calc_str": "pv[0]+10", "variables": "a:pv:name", "server": "fakeServer", "pv_name": "this:pv:name"})
@@ -46,6 +48,7 @@ class TestCalcRuleConfiguration:
         assert rule._pv_name == "this:pv:name"
 
     def test_set_calc_keeps_variable_list(self) -> None:
+        """A list of variable names is stored as-is."""
         rule = CalcRule()
 
         rule.set_calc({"variables": ["a:pv:name", "b:pv:name"]})
@@ -55,16 +58,19 @@ class TestCalcRuleConfiguration:
 
 class TestCalcRuleGetVariables:
     def test_get_variables_returns_values_in_order(self) -> None:
+        """Values are fetched in the same order as self._variables."""
         rule, _ = make_calc_rule("pv[0]", ["a:pv:name", "b:pv:name"], [1.0, 2.0])
 
         assert rule.get_variables() == [1.0, 2.0]
 
     def test_get_variables_returns_none_if_a_pv_is_missing(self) -> None:
+        """If any one variable's PV value is unavailable (None), the whole fetch fails."""
         rule, _ = make_calc_rule("pv[0]", ["a:pv:name", "b:pv:name"], [1.0, None])
 
         assert rule.get_variables() is None
 
     def test_get_variables_returns_none_on_exception(self) -> None:
+        """An exception fetching a PV value is treated the same as a missing value."""
         rule, server = make_calc_rule("pv[0]", ["a:pv:name"], [1.0])
         server.get_pv_value.side_effect = RuntimeError("boom")
 
@@ -73,6 +79,7 @@ class TestCalcRuleGetVariables:
 
 class TestCalcRulePostRule:
     def test_post_rule_evaluates_single_variable(self) -> None:
+        """calc_str is evaluated against a single dependent PV's value."""
         rule, _ = make_calc_rule("pv[0]+10", "a:pv:name", [1.0])
 
         old_state: Value = NTScalar("d").wrap(0.0)
@@ -84,6 +91,7 @@ class TestCalcRulePostRule:
         assert new_state["value"] == 11.0
 
     def test_post_rule_evaluates_multiple_variables_in_order(self) -> None:
+        """pv[0], pv[1], ... in calc_str map positionally to the configured variables."""
         rule, _ = make_calc_rule("pv[0]+2.12*pv[1]", ["a:pv:name", "b:pv:name"], [3.0, 4.0])
 
         new_state: Value = NTScalar("d").wrap(0.0)
@@ -93,6 +101,7 @@ class TestCalcRulePostRule:
         assert new_state["value"] == pytest.approx(3.0 + 2.12 * 4.0)
 
     def test_post_rule_supports_math_module_functions(self) -> None:
+        """calc_str can call functions from the math module via the "m" name."""
         rule, _ = make_calc_rule("pv[0]*m.sin(pv[1])", ["a:pv:name", "b:pv:name"], [3.0, 4.0])
 
         new_state: Value = NTScalar("d").wrap(0.0)
@@ -102,6 +111,7 @@ class TestCalcRulePostRule:
         assert new_state["value"] == pytest.approx(3.0 * math.sin(4.0))
 
     def test_post_rule_aborts_if_a_variable_is_missing(self) -> None:
+        """post_rule aborts rather than evaluating calc_str when a dependent PV is unavailable."""
         rule, _ = make_calc_rule("pv[0]", ["a:pv:name"], [None])
 
         new_state: Value = NTScalar("d").wrap(0.0)
@@ -119,6 +129,7 @@ class TestCalcRulePostRule:
         ],
     )
     def test_post_rule_rejects_unsafe_expressions(self, malicious_calc_str: str) -> None:
+        """simpleeval refuses to execute expressions outside its restricted grammar, e.g. sandbox escapes."""
         rule, _ = make_calc_rule(malicious_calc_str, ["a:pv:name"], [1.0])
 
         new_state: Value = NTScalar("d").wrap(0.0)

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.11'",
@@ -51,31 +51,23 @@ sdist = { url = "https://files.pythonhosted.org/packages/fc/97/c783634659c2920c3
 wheels = [
     { url = "https://files.pythonhosted.org/packages/de/cc/4635c320081c78d6ffc2cab0a76025b691a91204f4aa317d568ff9280a2d/cffi-1.17.1-cp310-cp310-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:edae79245293e15384b51f88b00613ba9f7198016a5948b5dddf4917d4d26382", size = 426024, upload-time = "2024-09-04T20:43:34.186Z" },
     { url = "https://files.pythonhosted.org/packages/b6/7b/3b2b250f3aab91abe5f8a51ada1b717935fdaec53f790ad4100fe2ec64d1/cffi-1.17.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:45398b671ac6d70e67da8e4224a065cec6a93541bb7aebe1b198a61b58c7b702", size = 448188, upload-time = "2024-09-04T20:43:36.286Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/48/1b9283ebbf0ec065148d8de05d647a986c5f22586b18120020452fff8f5d/cffi-1.17.1-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ad9413ccdeda48c5afdae7e4fa2192157e991ff761e7ab8fdd8926f40b160cc3", size = 455571, upload-time = "2024-09-04T20:43:38.586Z" },
-    { url = "https://files.pythonhosted.org/packages/40/87/3b8452525437b40f39ca7ff70276679772ee7e8b394934ff60e63b7b090c/cffi-1.17.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5da5719280082ac6bd9aa7becb3938dc9f9cbd57fac7d2871717b1feb0902ab6", size = 436687, upload-time = "2024-09-04T20:43:40.084Z" },
     { url = "https://files.pythonhosted.org/packages/8d/fb/4da72871d177d63649ac449aec2e8a29efe0274035880c7af59101ca2232/cffi-1.17.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2bb1a08b8008b281856e5971307cc386a8e9c5b625ac297e853d36da6efe9c17", size = 446211, upload-time = "2024-09-04T20:43:41.526Z" },
     { url = "https://files.pythonhosted.org/packages/ab/a0/62f00bcb411332106c02b663b26f3545a9ef136f80d5df746c05878f8c4b/cffi-1.17.1-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:045d61c734659cc045141be4bae381a41d89b741f795af1dd018bfb532fd0df8", size = 461325, upload-time = "2024-09-04T20:43:43.117Z" },
     { url = "https://files.pythonhosted.org/packages/36/83/76127035ed2e7e27b0787604d99da630ac3123bfb02d8e80c633f218a11d/cffi-1.17.1-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:6883e737d7d9e4899a8a695e00ec36bd4e5e4f18fabe0aca0efe0a4b44cdb13e", size = 438784, upload-time = "2024-09-04T20:43:45.256Z" },
     { url = "https://files.pythonhosted.org/packages/21/81/a6cd025db2f08ac88b901b745c163d884641909641f9b826e8cb87645942/cffi-1.17.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:6b8b4a92e1c65048ff98cfe1f735ef8f1ceb72e3d5f0c25fdb12087a23da22be", size = 461564, upload-time = "2024-09-04T20:43:46.779Z" },
     { url = "https://files.pythonhosted.org/packages/94/dd/a3f0118e688d1b1a57553da23b16bdade96d2f9bcda4d32e7d2838047ff7/cffi-1.17.1-cp311-cp311-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f75c7ab1f9e4aca5414ed4d8e5c0e303a34f4421f8a0d47a4d019ceff0ab6af4", size = 445259, upload-time = "2024-09-04T20:43:56.123Z" },
     { url = "https://files.pythonhosted.org/packages/2e/ea/70ce63780f096e16ce8588efe039d3c4f91deb1dc01e9c73a287939c79a6/cffi-1.17.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a1ed2dd2972641495a3ec98445e09766f077aee98a1c896dcb4ad0d303628e41", size = 469200, upload-time = "2024-09-04T20:43:57.891Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/a0/a4fa9f4f781bda074c3ddd57a572b060fa0df7655d2a4247bbe277200146/cffi-1.17.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:46bf43160c1a35f7ec506d254e5c890f3c03648a4dbac12d624e4490a7046cd1", size = 477235, upload-time = "2024-09-04T20:44:00.18Z" },
-    { url = "https://files.pythonhosted.org/packages/62/12/ce8710b5b8affbcdd5c6e367217c242524ad17a02fe5beec3ee339f69f85/cffi-1.17.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a24ed04c8ffd54b0729c07cee15a81d964e6fee0e3d4d342a27b020d22959dc6", size = 459721, upload-time = "2024-09-04T20:44:01.585Z" },
     { url = "https://files.pythonhosted.org/packages/ff/6b/d45873c5e0242196f042d555526f92aa9e0c32355a1be1ff8c27f077fd37/cffi-1.17.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:610faea79c43e44c71e1ec53a554553fa22321b65fae24889706c0a84d4ad86d", size = 467242, upload-time = "2024-09-04T20:44:03.467Z" },
     { url = "https://files.pythonhosted.org/packages/1a/52/d9a0e523a572fbccf2955f5abe883cfa8bcc570d7faeee06336fbd50c9fc/cffi-1.17.1-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:a9b15d491f3ad5d692e11f6b71f7857e7835eb677955c00cc0aefcd0669adaf6", size = 477999, upload-time = "2024-09-04T20:44:05.023Z" },
     { url = "https://files.pythonhosted.org/packages/44/74/f2a2460684a1a2d00ca799ad880d54652841a780c4c97b87754f660c7603/cffi-1.17.1-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:de2ea4b5833625383e464549fec1bc395c1bdeeb5f25c4a3a82b5a8c756ec22f", size = 454242, upload-time = "2024-09-04T20:44:06.444Z" },
     { url = "https://files.pythonhosted.org/packages/f8/4a/34599cac7dfcd888ff54e801afe06a19c17787dfd94495ab0c8d35fe99fb/cffi-1.17.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:fc48c783f9c87e60831201f2cce7f3b2e4846bf4d8728eabe54d60700b318a0b", size = 478604, upload-time = "2024-09-04T20:44:08.206Z" },
     { url = "https://files.pythonhosted.org/packages/cc/b6/db007700f67d151abadf508cbfd6a1884f57eab90b1bb985c4c8c02b0f28/cffi-1.17.1-cp312-cp312-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1257bdabf294dceb59f5e70c64a3e2f462c30c7ad68092d01bbbfb1c16b1ba36", size = 454803, upload-time = "2024-09-04T20:44:15.231Z" },
     { url = "https://files.pythonhosted.org/packages/1a/df/f8d151540d8c200eb1c6fba8cd0dfd40904f1b0682ea705c36e6c2e97ab3/cffi-1.17.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:da95af8214998d77a98cc14e3a3bd00aa191526343078b530ceb0bd710fb48a5", size = 478850, upload-time = "2024-09-04T20:44:17.188Z" },
-    { url = "https://files.pythonhosted.org/packages/28/c0/b31116332a547fd2677ae5b78a2ef662dfc8023d67f41b2a83f7c2aa78b1/cffi-1.17.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d63afe322132c194cf832bfec0dc69a99fb9bb6bbd550f161a49e9e855cc78ff", size = 485729, upload-time = "2024-09-04T20:44:18.688Z" },
-    { url = "https://files.pythonhosted.org/packages/91/2b/9a1ddfa5c7f13cab007a2c9cc295b70fbbda7cb10a286aa6810338e60ea1/cffi-1.17.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f79fc4fc25f1c8698ff97788206bb3c2598949bfe0fef03d299eb1b5356ada99", size = 471256, upload-time = "2024-09-04T20:44:20.248Z" },
     { url = "https://files.pythonhosted.org/packages/b2/d5/da47df7004cb17e4955df6a43d14b3b4ae77737dff8bf7f8f333196717bf/cffi-1.17.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b62ce867176a75d03a665bad002af8e6d54644fad99a3c70905c543130e39d93", size = 479424, upload-time = "2024-09-04T20:44:21.673Z" },
     { url = "https://files.pythonhosted.org/packages/0b/ac/2a28bcf513e93a219c8a4e8e125534f4f6db03e3179ba1c45e949b76212c/cffi-1.17.1-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:386c8bf53c502fff58903061338ce4f4950cbdcb23e2902d86c0f722b786bbe3", size = 484568, upload-time = "2024-09-04T20:44:23.245Z" },
     { url = "https://files.pythonhosted.org/packages/d4/38/ca8a4f639065f14ae0f1d9751e70447a261f1a30fa7547a828ae08142465/cffi-1.17.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:4ceb10419a9adf4460ea14cfd6bc43d08701f0835e979bf821052f1805850fe8", size = 488736, upload-time = "2024-09-04T20:44:24.757Z" },
     { url = "https://files.pythonhosted.org/packages/0e/2d/eab2e858a91fdff70533cab61dcff4a1f55ec60425832ddfdc9cd36bc8af/cffi-1.17.1-cp313-cp313-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d01b12eeeb4427d3110de311e1774046ad344f5b1a7403101878976ecd7a10f3", size = 454792, upload-time = "2024-09-04T20:44:32.01Z" },
     { url = "https://files.pythonhosted.org/packages/75/b2/fbaec7c4455c604e29388d55599b99ebcc250a60050610fadde58932b7ee/cffi-1.17.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:706510fe141c86a69c8ddc029c7910003a17353970cff3b904ff0686a5927683", size = 478893, upload-time = "2024-09-04T20:44:33.606Z" },
-    { url = "https://files.pythonhosted.org/packages/4f/b7/6e4a2162178bf1935c336d4da8a9352cccab4d3a5d7914065490f08c0690/cffi-1.17.1-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:de55b766c7aa2e2a3092c51e0483d700341182f08e67c63630d5b6f200bb28e5", size = 485810, upload-time = "2024-09-04T20:44:35.191Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/8a/1d0e4a9c26e54746dc08c2c6c037889124d4f59dffd853a659fa545f1b40/cffi-1.17.1-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c59d6e989d07460165cc5ad3c61f9fd8f1b4796eacbd81cee78957842b834af4", size = 471200, upload-time = "2024-09-04T20:44:36.743Z" },
     { url = "https://files.pythonhosted.org/packages/26/9f/1aab65a6c0db35f43c4d1b4f580e8df53914310afc10ae0397d29d697af4/cffi-1.17.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dd398dbc6773384a17fe0d3e7eeb8d1a21c2200473ee6806bb5e6a8e62bb73dd", size = 479447, upload-time = "2024-09-04T20:44:38.492Z" },
     { url = "https://files.pythonhosted.org/packages/5f/e4/fb8b3dd8dc0e98edf1135ff067ae070bb32ef9d509d6cb0f538cd6f7483f/cffi-1.17.1-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:3edc8d958eb099c634dace3c7e16560ae474aa3803a5df240542b305d14e14ed", size = 484358, upload-time = "2024-09-04T20:44:40.046Z" },
     { url = "https://files.pythonhosted.org/packages/f1/47/d7145bf2dc04684935d57d67dff9d6d795b2ba2796806bb109864be3a151/cffi-1.17.1-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:72e72408cad3d5419375fc87d289076ee319835bdfa2caad331e377589aebba9", size = 488469, upload-time = "2024-09-04T20:44:41.616Z" },
@@ -691,6 +683,7 @@ source = { editable = "." }
 dependencies = [
     { name = "p4p" },
     { name = "pyyaml" },
+    { name = "simpleeval" },
 ]
 
 [package.optional-dependencies]
@@ -712,6 +705,7 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'test'", specifier = ">=8.4" },
     { name = "pyyaml", specifier = ">=6.0.2" },
     { name = "ruff", marker = "extra == 'test'", specifier = ">=0.12" },
+    { name = "simpleeval", specifier = ">=1.0.3" },
     { name = "twine", marker = "extra == 'dist'", specifier = ">=6.1.0" },
 ]
 provides-extras = ["dist", "test"]
@@ -991,6 +985,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f0/eb/cd5d9e2894606d62e08edcfb52dcf20ff66c697ec36c47d44c397feeab01/setuptools_dso-2.12.3.tar.gz", hash = "sha256:9effb7bc38f87ff9aed33cc69e860320804ca6c69af8896dbba10996a49b5d7e", size = 21510, upload-time = "2026-02-11T01:16:01.139Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/51/6b/3feec8016ab2263946c4480510d2d1a7924a5400c455974a7a0344bb4304/setuptools_dso-2.12.3-py2.py3-none-any.whl", hash = "sha256:5040be8628bd6cb82653391cf59f22126b261941cdbc9c36becca87e09c011c3", size = 23950, upload-time = "2026-02-11T01:16:00.295Z" },
+]
+
+[[package]]
+name = "simpleeval"
+version = "1.0.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b4/9d/e7c9309940794dd3073cba2e5101df5874d84243595ce63b1e1c8f9b9c76/simpleeval-1.0.7.tar.gz", hash = "sha256:1e10e5f9fec597814444e20c0892ed15162fa214c8a88f434b5b077cf2fef85b", size = 30250, upload-time = "2026-03-16T10:53:03.464Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0f/2f/f32aa85591882378bb43caa09363f3ed97df399369a5144c7f19f2275bc0/simpleeval-1.0.7-py3-none-any.whl", hash = "sha256:97ac271bfd8f2af9e7b9a36ceea67617f26fa873f9d5ae1922f64d4c1442534b", size = 18792, upload-time = "2026-03-16T10:53:02.103Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Using the simpleeval library ought to be safer than using a naked `eval()`.

This includes some Claude generated unit tests, some general busy-body tidying up of the file due to stricter ruff checks and my love of type-hinting. The actual key change is at line 138 of the old code / 150 of the new revised code.